### PR TITLE
Tracking changes to Svelte template

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name": "svelte-app",
     "version": "1.0.0",
     "devDependencies": {
-        "npm-run-all": "^4.1.5",
         "rollup": "^1.12.0",
         "rollup-plugin-babel": "^4.3.3",
         "rollup-plugin-commonjs": "^10.0.0",
@@ -14,15 +13,12 @@
         "svelte": "^3.0.0"
     },
     "dependencies": {
-        "livereload": "^0.8.0",
         "sirv-cli": "^0.4.4",
         "svelte-filerouter": "^1.3.0"
     },
     "scripts": {
         "build": "rollup -c",
-        "autobuild": "rollup -c -w",
-        "dev": "run-p start:dev autobuild",
-        "start": "sirv public --single",
-        "start:dev": "sirv public --single --dev"
+        "dev": "rollup -c -w",
+        "start": "sirv public --single"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,11 @@ export default {
             dedupe: importee => importee === 'svelte' || importee.startsWith('svelte/')
         }),
         commonjs(),
+
+        // In dev mode, call `npm run start` once
+        // the bundle has been generated
+        !production && serve(),
+
         // Watch the `public` directory and refresh the
         // browser on changes when not in production
         !production && livereload('public'),
@@ -57,3 +62,20 @@ export default {
         clearScreen: false
     }
 };
+
+function serve() {
+    let started = false;
+
+    return {
+        writeBundle() {
+            if (!started) {
+                started = true;
+
+                require('child_process').spawn('npm', ['run', 'start', '--', '--dev'], {
+                    stdio: ['ignore', 'inherit', 'inherit'],
+                    shell: true
+                });
+            }
+        }
+    };
+}


### PR DESCRIPTION
The Svelte template has experienced some changes, recently:

https://github.com/sveltejs/template/commit/51c56eb3ec9abafec8e3194cc43e8a92cfa206d6
https://github.com/sveltejs/template/commit/7b0bb3279dd1bc0fb5e60eccc65a3422395c8f62

As a newbie to Svelte ecosystem, it would feel nice to have different templates relatively close by, so prepared this PR to bring the same changes to svelter-filerouter-example.